### PR TITLE
feat: Add concurrency limiting for AI tasks via DAGU queues

### DIFF
--- a/docs/concurrency-plan.md
+++ b/docs/concurrency-plan.md
@@ -1,0 +1,297 @@
+# Concurrency Limiting Plan for Agent Arborist
+
+## Overview
+
+This plan adds **simple concurrency limiting** using DAGU's queue system to control the maximum number of concurrent AI tasks.
+
+**Design Principle**: KISS - Keep It Simple. Since DAGs don't embed runner/model info (resolved at runtime), we use a single queue for all AI steps.
+
+## Background
+
+### DAGU Queue System
+
+From DAGU documentation:
+- DAGU supports global queues defined in `~/.config/dagu/config.yaml`
+- Each queue has a `maxConcurrency` limit
+- DAGs can be assigned to queues via the `queue` field in YAML
+- If no queue is assigned, DAGs use a local queue with concurrency of 1
+
+### Current Arborist Architecture
+
+- DAG commands are simple: `arborist task run T001` (no --runner/--model flags)
+- Runner/model resolved at **runtime** from config, not at DAG generation time
+- This means we can't differentiate queues by runner/model at DAG build time
+
+### Why Simple?
+
+Since we don't know which runner/model will execute until runtime:
+- ❌ Can't do per-runner queues (`arborist:claude`)
+- ❌ Can't do per-model queues (`arborist:claude:sonnet`)
+- ✅ Can only limit total concurrent AI steps
+
+## Configuration
+
+Add to global (`~/.arborist_config.json`) or project (`.arborist/config.json`) config:
+
+```json
+{
+  "concurrency": {
+    "max_ai_tasks": 2
+  }
+}
+```
+
+That's it. One number.
+
+### Environment Variable
+
+```bash
+export ARBORIST_MAX_AI_TASKS=2
+```
+
+## Implementation
+
+### 1. Add Config Field
+
+```python
+# src/agent_arborist/config.py
+
+@dataclass
+class ConcurrencyConfig:
+    max_ai_tasks: int = 2  # Default: 2 concurrent AI tasks
+
+@dataclass
+class ArboristConfig:
+    # ... existing fields ...
+    concurrency: ConcurrencyConfig = field(default_factory=ConcurrencyConfig)
+```
+
+### 2. Add Queue Field to SubDagStep
+
+```python
+# src/agent_arborist/dag_builder.py
+
+@dataclass
+class SubDagStep:
+    name: str
+    command: str | None = None
+    call: str | None = None
+    depends: list[str] = field(default_factory=list)
+    output: str | None = None
+    queue: str | None = None  # NEW
+```
+
+### 3. Assign Queue to AI Steps
+
+```python
+def _build_leaf_subdag(self, task_id: str) -> SubDag:
+    # ... existing code ...
+
+    # Run step - uses AI queue
+    steps.append(SubDagStep(
+        name="run",
+        command=f"arborist task run {task_id}",
+        depends=["pre-sync"],
+        output=output_var("run"),
+        queue="arborist:ai",  # Rate limited
+    ))
+
+    # Commit step - no queue (git operations, not rate limited)
+    steps.append(SubDagStep(
+        name="commit",
+        command=f"arborist task commit {task_id}",
+        depends=["run"],
+    ))
+
+    # Post-merge step - uses AI queue
+    steps.append(SubDagStep(
+        name="post-merge",
+        command=f"arborist task post-merge {task_id}",
+        depends=["run-test"],
+        output=output_var("post-merge"),
+        queue="arborist:ai",  # Rate limited
+    ))
+```
+
+### 4. Generate DAGU Queue Config
+
+```python
+# src/agent_arborist/cli.py
+
+@config.command("sync-queues")
+def config_sync_queues() -> None:
+    """Sync concurrency config to DAGU queues."""
+    config = get_config()
+
+    dagu_home = Path(os.environ.get("DAGU_HOME", "~/.config/dagu")).expanduser()
+    dagu_config_path = dagu_home / "config.yaml"
+
+    # Read existing or create new
+    if dagu_config_path.exists():
+        dagu_config = yaml.safe_load(dagu_config_path.read_text()) or {}
+    else:
+        dagu_config = {}
+
+    # Set queue config
+    dagu_config["queues"] = {
+        "enabled": True,
+        "config": [
+            {
+                "name": "arborist:ai",
+                "maxConcurrency": config.concurrency.max_ai_tasks
+            }
+        ]
+    }
+
+    dagu_config_path.parent.mkdir(parents=True, exist_ok=True)
+    dagu_config_path.write_text(yaml.dump(dagu_config, default_flow_style=False))
+
+    click.echo(
+        f"✓ Queue 'arborist:ai' set to max {config.concurrency.max_ai_tasks} concurrent tasks"
+    )
+```
+
+### 5. Update _step_to_dict
+
+```python
+def _step_to_dict(self, step: SubDagStep) -> dict[str, Any]:
+    d: dict[str, Any] = {"name": step.name}
+
+    if step.command is not None:
+        d["command"] = step.command
+    if step.call is not None:
+        d["call"] = step.call
+    if step.depends:
+        d["depends"] = step.depends
+    if step.output is not None:
+        d["output"] = step.output
+    if step.queue is not None:
+        d["queue"] = step.queue
+
+    return d
+```
+
+## Which Steps Get Rate Limited?
+
+| Step | Queue | Why |
+|------|-------|-----|
+| `run` | `arborist:ai` | AI task execution |
+| `post-merge` | `arborist:ai` | AI-assisted merging |
+| `pre-sync` | None | Git operations |
+| `commit` | None | Git operations |
+| `run-test` | None | Test execution |
+| `container-up/down` | None | Docker lifecycle |
+| `branches-setup` | None | Branch management |
+
+## Generated DAG Example
+
+```yaml
+name: T001
+steps:
+  - name: pre-sync
+    command: arborist task pre-sync T001
+
+  - name: run
+    command: arborist task run T001
+    depends: [pre-sync]
+    queue: arborist:ai              # ← Rate limited
+
+  - name: commit
+    command: arborist task commit T001
+    depends: [run]
+
+  - name: run-test
+    command: arborist task run-test T001
+    depends: [commit]
+
+  - name: post-merge
+    command: arborist task post-merge T001
+    depends: [run-test]
+    queue: arborist:ai              # ← Rate limited
+```
+
+## Generated DAGU Config
+
+```yaml
+# ~/.config/dagu/config.yaml
+queues:
+  enabled: true
+  config:
+    - name: arborist:ai
+      maxConcurrency: 2
+```
+
+## Usage
+
+```bash
+# Set concurrency limit
+echo '{"concurrency": {"max_ai_tasks": 3}}' > .arborist/config.json
+
+# Sync to DAGU
+arborist config sync-queues
+
+# Build DAG (automatically includes queue assignments)
+arborist spec dag-build my-spec
+
+# Run - DAGU will limit to 3 concurrent AI steps
+arborist dag run my-spec
+```
+
+## Testing
+
+```python
+# tests/test_concurrency.py
+
+def test_ai_steps_have_queue():
+    """AI steps should have arborist:ai queue."""
+    builder = SubDagBuilder(DagConfig(name="test"))
+    subdag = builder._build_leaf_subdag("T001")
+
+    run_step = next(s for s in subdag.steps if s.name == "run")
+    assert run_step.queue == "arborist:ai"
+
+    post_merge = next(s for s in subdag.steps if s.name == "post-merge")
+    assert post_merge.queue == "arborist:ai"
+
+def test_non_ai_steps_no_queue():
+    """Non-AI steps should not have queue."""
+    builder = SubDagBuilder(DagConfig(name="test"))
+    subdag = builder._build_leaf_subdag("T001")
+
+    for step_name in ["pre-sync", "commit", "run-test"]:
+        step = next(s for s in subdag.steps if s.name == step_name)
+        assert step.queue is None
+
+def test_config_sync_queues(tmp_path, monkeypatch):
+    """sync-queues should create DAGU config."""
+    monkeypatch.setenv("DAGU_HOME", str(tmp_path))
+
+    # Set config
+    config = ArboristConfig()
+    config.concurrency.max_ai_tasks = 3
+
+    # Run sync
+    sync_queues(config)
+
+    # Verify
+    dagu_config = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert dagu_config["queues"]["config"][0]["name"] == "arborist:ai"
+    assert dagu_config["queues"]["config"][0]["maxConcurrency"] == 3
+```
+
+## Success Criteria
+
+- [ ] Single `concurrency.max_ai_tasks` config option
+- [ ] `ARBORIST_MAX_AI_TASKS` environment variable support
+- [ ] `arborist config sync-queues` generates DAGU queue config
+- [ ] DAG generation adds `queue: arborist:ai` to `run` and `post-merge` steps
+- [ ] Tests verify queue assignment
+- [ ] Backward compatible (no queue = unlimited)
+
+## Future Considerations
+
+If we later need per-runner/model limits, we could:
+1. Embed runner/model in DAG commands (architecture change)
+2. Or accept the current simple approach is sufficient
+
+For now: **KISS**

--- a/src/agent_arborist/cli.py
+++ b/src/agent_arborist/cli.py
@@ -807,6 +807,68 @@ def config_validate(ctx: click.Context) -> None:
         console.print("\n[green]All config files are valid![/green]")
 
 
+@config.command("sync-queues")
+@click.pass_context
+def config_sync_queues(ctx: click.Context) -> None:
+    """Sync concurrency config to DAGU queue definitions.
+
+    Reads the arborist configuration and generates DAGU queue config
+    for concurrency limiting. This creates or updates the queue definition
+    in ~/.config/dagu/config.yaml (or $DAGU_HOME/config.yaml).
+
+    The queue 'arborist:ai' is used to limit concurrent AI tasks
+    (run and post-merge steps).
+
+    Example:
+        arborist config sync-queues
+    """
+    import os
+    from pathlib import Path
+
+    import yaml
+
+    from agent_arborist.config import get_config
+    from agent_arborist.dag_builder import AI_TASK_QUEUE
+
+    arborist_home = ctx.obj.get("arborist_home")
+    config = get_config(arborist_home)
+
+    # Determine DAGU config path
+    dagu_home = Path(os.environ.get("DAGU_HOME", "~/.config/dagu")).expanduser()
+    dagu_config_path = dagu_home / "config.yaml"
+
+    # Read existing config or create new
+    if dagu_config_path.exists():
+        try:
+            dagu_config = yaml.safe_load(dagu_config_path.read_text()) or {}
+        except yaml.YAMLError as e:
+            console.print(f"[red]Error parsing DAGU config:[/red] {e}")
+            raise SystemExit(1)
+    else:
+        dagu_config = {}
+
+    # Set queue config
+    dagu_config["queues"] = {
+        "enabled": True,
+        "config": [
+            {
+                "name": AI_TASK_QUEUE,
+                "maxConcurrency": config.concurrency.max_ai_tasks,
+            }
+        ],
+    }
+
+    # Write back
+    dagu_config_path.parent.mkdir(parents=True, exist_ok=True)
+    dagu_config_path.write_text(yaml.dump(dagu_config, default_flow_style=False, sort_keys=False))
+
+    console.print(f"[green]✓[/green] Queue config synced to {dagu_config_path}")
+    console.print(
+        f"[green]✓[/green] Queue '{AI_TASK_QUEUE}' set to max "
+        f"{config.concurrency.max_ai_tasks} concurrent tasks"
+    )
+
+
 # -----------------------------------------------------------------------------
 # Task commands
 # -----------------------------------------------------------------------------

--- a/src/agent_arborist/config.py
+++ b/src/agent_arborist/config.py
@@ -41,6 +41,7 @@ ENV_TIMEOUT_TASK_RUN = "ARBORIST_TIMEOUT_TASK_RUN"
 ENV_TIMEOUT_POST_MERGE = "ARBORIST_TIMEOUT_POST_MERGE"
 ENV_TEST_COMMAND = "ARBORIST_TEST_COMMAND"
 ENV_TEST_TIMEOUT = "ARBORIST_TEST_TIMEOUT"
+ENV_MAX_AI_TASKS = "ARBORIST_MAX_AI_TASKS"
 
 # Deprecated env vars (backward compatibility)
 ENV_DEFAULT_RUNNER_DEPRECATED = "ARBORIST_DEFAULT_RUNNER"
@@ -320,6 +321,41 @@ class PathsConfig:
 
 
 @dataclass
+class ConcurrencyConfig:
+    """Concurrency limiting configuration for AI tasks."""
+
+    max_ai_tasks: int = 2  # Default: 2 concurrent AI tasks
+
+    def validate(self) -> None:
+        """Validate concurrency values."""
+        if self.max_ai_tasks <= 0:
+            raise ConfigValidationError(
+                f"max_ai_tasks must be positive, got {self.max_ai_tasks}"
+            )
+
+    def to_dict(self, exclude_none: bool = False) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {"max_ai_tasks": self.max_ai_tasks}
+
+    @classmethod
+    def from_dict(
+        cls, data: dict[str, Any], strict: bool = False
+    ) -> "ConcurrencyConfig":
+        """Create from dictionary."""
+        if strict:
+            known_fields = {f.name for f in fields(cls)}
+            unknown = set(data.keys()) - known_fields
+            if unknown:
+                raise ConfigValidationError(
+                    f"Unknown fields in concurrency config: {', '.join(unknown)}"
+                )
+
+        return cls(
+            max_ai_tasks=data.get("max_ai_tasks", 2),
+        )
+
+
+@dataclass
 class ArboristConfig:
     """Main configuration container."""
 
@@ -335,11 +371,13 @@ class ArboristConfig:
     test: TestingConfig = field(default_factory=TestingConfig)
     paths: PathsConfig = field(default_factory=PathsConfig)
     runners: dict[str, RunnerConfig] = field(default_factory=dict)
+    concurrency: ConcurrencyConfig = field(default_factory=ConcurrencyConfig)
 
     def validate(self) -> None:
         """Validate entire configuration."""
         self.defaults.validate()
         self.timeouts.validate()
+        self.concurrency.validate()
 
         # Validate step names
         for step_name in self.steps:
@@ -360,6 +398,7 @@ class ArboristConfig:
             "test": self.test.to_dict(exclude_none),
             "paths": self.paths.to_dict(exclude_none),
             "runners": {k: v.to_dict(exclude_none) for k, v in self.runners.items()},
+            "concurrency": self.concurrency.to_dict(exclude_none),
         }
 
     @classmethod
@@ -374,6 +413,7 @@ class ArboristConfig:
                 "test",
                 "paths",
                 "runners",
+                "concurrency",
             }
             unknown = set(data.keys()) - known_fields
             if unknown:
@@ -407,6 +447,7 @@ class ArboristConfig:
             test=TestingConfig.from_dict(data.get("test", {}), strict),
             paths=PathsConfig.from_dict(data.get("paths", {}), strict),
             runners=runners,
+            concurrency=ConcurrencyConfig.from_dict(data.get("concurrency", {}), strict),
         )
 
 
@@ -522,6 +563,10 @@ def merge_configs(*configs: ArboristConfig) -> ArboristConfig:
             if runner_config.timeout is not None:
                 result.runners[runner_name].timeout = runner_config.timeout
 
+        # Merge concurrency (only non-default values)
+        if config.concurrency.max_ai_tasks != 2:
+            result.concurrency.max_ai_tasks = config.concurrency.max_ai_tasks
+
     return result
 
 
@@ -616,6 +661,15 @@ def apply_env_overrides(config: ArboristConfig) -> ArboristConfig:
             if step_name not in result.steps:
                 result.steps[step_name] = StepConfig()
             result.steps[step_name].model = step_model
+
+    # Concurrency overrides
+    if max_ai_tasks_str := os.environ.get(ENV_MAX_AI_TASKS):
+        try:
+            result.concurrency.max_ai_tasks = int(max_ai_tasks_str)
+        except ValueError:
+            raise ConfigValidationError(
+                f"{ENV_MAX_AI_TASKS} must be an integer, got '{max_ai_tasks_str}'"
+            )
 
     return result
 
@@ -805,6 +859,10 @@ def generate_config_template() -> dict[str, Any]:
                 },
                 "_comment": "Gemini runner configuration",
             },
+        },
+        "concurrency": {
+            "max_ai_tasks": 2,
+            "_comment_max_ai_tasks": "Maximum concurrent AI tasks (run + post-merge steps)",
         },
     }
 

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,460 @@
+"""Tests for concurrency limiting feature."""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from agent_arborist.config import (
+    ArboristConfig,
+    ConcurrencyConfig,
+    ConfigValidationError,
+    apply_env_overrides,
+    get_config,
+    merge_configs,
+)
+from agent_arborist.dag_builder import (
+    AI_TASK_QUEUE,
+    DagConfig,
+    SubDagBuilder,
+    SubDagStep,
+)
+from agent_arborist.task_spec import TaskSpec, Task, Phase
+from agent_arborist.task_state import TaskTree, TaskNode
+
+
+def make_spec(tasks: list[Task], dependencies: dict[str, list[str]] | None = None) -> TaskSpec:
+    """Helper to create a TaskSpec from a list of tasks."""
+    return TaskSpec(
+        project="Test project",
+        total_tasks=len(tasks),
+        phases=[Phase(name="Phase 1", tasks=tasks)],
+        dependencies=dependencies or {},
+    )
+
+
+class TestConcurrencyConfig:
+    """Tests for ConcurrencyConfig dataclass."""
+
+    def test_default_values(self):
+        """Test default concurrency values."""
+        config = ConcurrencyConfig()
+        assert config.max_ai_tasks == 2
+
+    def test_custom_values(self):
+        """Test custom concurrency values."""
+        config = ConcurrencyConfig(max_ai_tasks=10)
+        assert config.max_ai_tasks == 10
+
+    def test_validate_positive(self):
+        """Test validation passes for positive values."""
+        config = ConcurrencyConfig(max_ai_tasks=1)
+        config.validate()  # Should not raise
+
+    def test_validate_zero_raises(self):
+        """Test validation fails for zero."""
+        config = ConcurrencyConfig(max_ai_tasks=0)
+        with pytest.raises(ConfigValidationError, match="must be positive"):
+            config.validate()
+
+    def test_validate_negative_raises(self):
+        """Test validation fails for negative values."""
+        config = ConcurrencyConfig(max_ai_tasks=-1)
+        with pytest.raises(ConfigValidationError, match="must be positive"):
+            config.validate()
+
+    def test_to_dict(self):
+        """Test conversion to dictionary."""
+        config = ConcurrencyConfig(max_ai_tasks=3)
+        d = config.to_dict()
+        assert d == {"max_ai_tasks": 3}
+
+    def test_from_dict(self):
+        """Test creation from dictionary."""
+        config = ConcurrencyConfig.from_dict({"max_ai_tasks": 7})
+        assert config.max_ai_tasks == 7
+
+    def test_from_dict_default(self):
+        """Test creation from empty dictionary uses defaults."""
+        config = ConcurrencyConfig.from_dict({})
+        assert config.max_ai_tasks == 2
+
+    def test_from_dict_strict_unknown_field(self):
+        """Test strict mode rejects unknown fields."""
+        with pytest.raises(ConfigValidationError, match="Unknown fields"):
+            ConcurrencyConfig.from_dict({"unknown_field": 1}, strict=True)
+
+
+class TestArboristConfigConcurrency:
+    """Tests for concurrency in ArboristConfig."""
+
+    def test_default_concurrency(self):
+        """Test ArboristConfig has default concurrency."""
+        config = ArboristConfig()
+        assert config.concurrency.max_ai_tasks == 2
+
+    def test_to_dict_includes_concurrency(self):
+        """Test to_dict includes concurrency section."""
+        config = ArboristConfig()
+        config.concurrency.max_ai_tasks = 3
+        d = config.to_dict()
+        assert "concurrency" in d
+        assert d["concurrency"]["max_ai_tasks"] == 3
+
+    def test_from_dict_with_concurrency(self):
+        """Test from_dict parses concurrency section."""
+        data = {
+            "concurrency": {"max_ai_tasks": 10}
+        }
+        config = ArboristConfig.from_dict(data)
+        assert config.concurrency.max_ai_tasks == 10
+
+    def test_from_dict_without_concurrency(self):
+        """Test from_dict uses default when concurrency not specified."""
+        config = ArboristConfig.from_dict({})
+        assert config.concurrency.max_ai_tasks == 2
+
+    def test_validate_includes_concurrency(self):
+        """Test validate checks concurrency."""
+        config = ArboristConfig()
+        config.concurrency.max_ai_tasks = 0
+        with pytest.raises(ConfigValidationError, match="must be positive"):
+            config.validate()
+
+
+class TestMergeConfigsConcurrency:
+    """Tests for merging concurrency config."""
+
+    def test_merge_overrides_non_default(self):
+        """Test merging overrides non-default concurrency values."""
+        base = ArboristConfig()
+        override = ArboristConfig()
+        override.concurrency.max_ai_tasks = 10
+
+        merged = merge_configs(base, override)
+        assert merged.concurrency.max_ai_tasks == 10
+
+    def test_merge_keeps_base_if_override_is_default(self):
+        """Test merging keeps base value if override is default."""
+        base = ArboristConfig()
+        base.concurrency.max_ai_tasks = 10
+        override = ArboristConfig()  # Default is 5
+
+        merged = merge_configs(base, override)
+        # Default (5) doesn't override non-default (10)
+        assert merged.concurrency.max_ai_tasks == 10
+
+
+class TestEnvOverridesConcurrency:
+    """Tests for environment variable overrides."""
+
+    def test_env_override_max_ai_tasks(self, monkeypatch):
+        """Test ARBORIST_MAX_AI_TASKS environment variable."""
+        monkeypatch.setenv("ARBORIST_MAX_AI_TASKS", "15")
+
+        config = ArboristConfig()
+        result = apply_env_overrides(config)
+
+        assert result.concurrency.max_ai_tasks == 15
+
+    def test_env_override_invalid_value(self, monkeypatch):
+        """Test invalid environment variable value raises error."""
+        monkeypatch.setenv("ARBORIST_MAX_AI_TASKS", "not-a-number")
+
+        config = ArboristConfig()
+        with pytest.raises(ConfigValidationError, match="must be an integer"):
+            apply_env_overrides(config)
+
+
+class TestSubDagStepQueue:
+    """Tests for SubDagStep queue field."""
+
+    def test_queue_field_default_none(self):
+        """Test queue field defaults to None."""
+        step = SubDagStep(name="test")
+        assert step.queue is None
+
+    def test_queue_field_custom_value(self):
+        """Test queue field can be set."""
+        step = SubDagStep(name="test", queue="my-queue")
+        assert step.queue == "my-queue"
+
+
+class TestDagBuilderQueues:
+    """Tests for queue assignment in DAG builder."""
+
+    def _create_simple_tree(self) -> TaskTree:
+        """Create a simple task tree with one leaf task."""
+        tree = TaskTree(spec_id="test")
+        tree.tasks["T001"] = TaskNode(
+            task_id="T001",
+            description="Test task"
+        )
+        tree.root_tasks = ["T001"]
+        return tree
+
+    def _create_parent_child_tree(self) -> TaskTree:
+        """Create a task tree with parent and child."""
+        tree = TaskTree(spec_id="test")
+        tree.tasks["T001"] = TaskNode(
+            task_id="T001",
+            description="Parent task",
+            children=["T002"]
+        )
+        tree.tasks["T002"] = TaskNode(
+            task_id="T002",
+            description="Child task",
+            parent_id="T001"
+        )
+        tree.root_tasks = ["T001"]
+        return tree
+
+    def test_ai_task_queue_constant(self):
+        """Test AI_TASK_QUEUE constant value."""
+        assert AI_TASK_QUEUE == "arborist:ai"
+
+    def test_leaf_run_step_has_queue(self):
+        """Test run step in leaf subdag has AI queue."""
+        dag_config = DagConfig(name="test")
+        builder = SubDagBuilder(dag_config)
+        tree = self._create_simple_tree()
+
+        spec = make_spec([Task(id="T001", description="Test")])
+        bundle = builder.build(spec, tree)
+
+        # Find T001 subdag
+        t001_subdag = next(s for s in bundle.subdags if s.name == "T001")
+
+        # Find run step
+        run_step = next(s for s in t001_subdag.steps if s.name == "run")
+        assert run_step.queue == AI_TASK_QUEUE
+
+    def test_leaf_post_merge_step_has_queue(self):
+        """Test post-merge step in leaf subdag has AI queue."""
+        dag_config = DagConfig(name="test")
+        builder = SubDagBuilder(dag_config)
+        tree = self._create_simple_tree()
+
+        spec = make_spec([Task(id="T001", description="Test")])
+        bundle = builder.build(spec, tree)
+
+        # Find T001 subdag
+        t001_subdag = next(s for s in bundle.subdags if s.name == "T001")
+
+        # Find post-merge step
+        post_merge_step = next(s for s in t001_subdag.steps if s.name == "post-merge")
+        assert post_merge_step.queue == AI_TASK_QUEUE
+
+    def test_leaf_non_ai_steps_no_queue(self):
+        """Test non-AI steps don't have queue."""
+        dag_config = DagConfig(name="test")
+        builder = SubDagBuilder(dag_config)
+        tree = self._create_simple_tree()
+
+        spec = make_spec([Task(id="T001", description="Test")])
+        bundle = builder.build(spec, tree)
+
+        # Find T001 subdag
+        t001_subdag = next(s for s in bundle.subdags if s.name == "T001")
+
+        # Check non-AI steps
+        for step_name in ["pre-sync", "commit", "run-test"]:
+            step = next((s for s in t001_subdag.steps if s.name == step_name), None)
+            if step:
+                assert step.queue is None, f"{step_name} should not have a queue"
+
+    def test_parent_complete_step_has_queue(self):
+        """Test complete step in parent subdag has AI queue."""
+        dag_config = DagConfig(name="test")
+        builder = SubDagBuilder(dag_config)
+        tree = self._create_parent_child_tree()
+
+        spec = make_spec(
+            [
+                Task(id="T001", description="Parent"),
+                Task(id="T002", description="Child")
+            ],
+            dependencies={"T002": ["T001"]}
+        )
+        bundle = builder.build(spec, tree)
+
+        # Find T001 subdag (parent)
+        t001_subdag = next(s for s in bundle.subdags if s.name == "T001")
+
+        # Find complete step
+        complete_step = next(s for s in t001_subdag.steps if s.name == "complete")
+        assert complete_step.queue == AI_TASK_QUEUE
+
+    def test_generated_yaml_includes_queue(self):
+        """Test generated YAML includes queue field."""
+        dag_config = DagConfig(name="test", spec_id="test")
+        builder = SubDagBuilder(dag_config)
+        tree = self._create_simple_tree()
+
+        spec = make_spec([Task(id="T001", description="Test")])
+        yaml_content = builder.build_yaml(spec, tree)
+
+        # Parse YAML
+        documents = list(yaml.safe_load_all(yaml_content))
+
+        # Find T001 subdag
+        t001_doc = next(d for d in documents if d.get("name") == "T001")
+
+        # Find run step
+        run_step = next(s for s in t001_doc["steps"] if s["name"] == "run")
+        assert run_step["queue"] == AI_TASK_QUEUE
+
+        # Find post-merge step
+        post_merge_step = next(s for s in t001_doc["steps"] if s["name"] == "post-merge")
+        assert post_merge_step["queue"] == AI_TASK_QUEUE
+
+    def test_generated_yaml_non_ai_steps_no_queue(self):
+        """Test non-AI steps don't have queue in YAML."""
+        dag_config = DagConfig(name="test", spec_id="test")
+        builder = SubDagBuilder(dag_config)
+        tree = self._create_simple_tree()
+
+        spec = make_spec([Task(id="T001", description="Test")])
+        yaml_content = builder.build_yaml(spec, tree)
+
+        # Parse YAML
+        documents = list(yaml.safe_load_all(yaml_content))
+
+        # Find T001 subdag
+        t001_doc = next(d for d in documents if d.get("name") == "T001")
+
+        # Check pre-sync step doesn't have queue
+        pre_sync_step = next(s for s in t001_doc["steps"] if s["name"] == "pre-sync")
+        assert "queue" not in pre_sync_step
+
+
+class TestConfigSyncQueues:
+    """Tests for config sync-queues CLI command."""
+
+    def test_sync_queues_creates_config(self, tmp_path, monkeypatch):
+        """Test sync-queues creates DAGU config file."""
+        from click.testing import CliRunner
+
+        from agent_arborist.cli import main
+
+        # Set DAGU_HOME to temp directory
+        dagu_home = tmp_path / "dagu"
+        monkeypatch.setenv("DAGU_HOME", str(dagu_home))
+
+        # Run CLI command
+        runner = CliRunner()
+        result = runner.invoke(main, ["config", "sync-queues"])
+
+        assert result.exit_code == 0, result.output
+        assert "Queue config synced" in result.output
+
+        # Check config file was created
+        config_path = dagu_home / "config.yaml"
+        assert config_path.exists()
+
+        # Check content
+        config = yaml.safe_load(config_path.read_text())
+        assert config["queues"]["enabled"] is True
+        assert len(config["queues"]["config"]) == 1
+        assert config["queues"]["config"][0]["name"] == AI_TASK_QUEUE
+        assert config["queues"]["config"][0]["maxConcurrency"] == 2  # Default
+
+    def test_sync_queues_uses_config_value(self, tmp_path, monkeypatch):
+        """Test sync-queues uses configured max_ai_tasks."""
+        from click.testing import CliRunner
+
+        from agent_arborist.cli import main
+
+        # Set DAGU_HOME to temp directory
+        dagu_home = tmp_path / "dagu"
+        monkeypatch.setenv("DAGU_HOME", str(dagu_home))
+
+        # Set custom max_ai_tasks via env var
+        monkeypatch.setenv("ARBORIST_MAX_AI_TASKS", "10")
+
+        # Run CLI command
+        runner = CliRunner()
+        result = runner.invoke(main, ["config", "sync-queues"])
+
+        assert result.exit_code == 0, result.output
+        assert "max 10 concurrent" in result.output
+
+        # Check content
+        config_path = dagu_home / "config.yaml"
+        config = yaml.safe_load(config_path.read_text())
+        assert config["queues"]["config"][0]["maxConcurrency"] == 10
+
+    def test_sync_queues_preserves_existing_config(self, tmp_path, monkeypatch):
+        """Test sync-queues preserves other DAGU config sections."""
+        from click.testing import CliRunner
+
+        from agent_arborist.cli import main
+
+        # Set DAGU_HOME to temp directory
+        dagu_home = tmp_path / "dagu"
+        dagu_home.mkdir(parents=True)
+        monkeypatch.setenv("DAGU_HOME", str(dagu_home))
+
+        # Create existing config with other settings
+        existing_config = {
+            "dagsDir": "/custom/dags",
+            "logDir": "/custom/logs",
+        }
+        config_path = dagu_home / "config.yaml"
+        config_path.write_text(yaml.dump(existing_config))
+
+        # Run CLI command
+        runner = CliRunner()
+        result = runner.invoke(main, ["config", "sync-queues"])
+
+        assert result.exit_code == 0, result.output
+
+        # Check existing settings preserved
+        config = yaml.safe_load(config_path.read_text())
+        assert config["dagsDir"] == "/custom/dags"
+        assert config["logDir"] == "/custom/logs"
+        assert config["queues"]["enabled"] is True
+
+
+class TestConfigFileIntegration:
+    """Integration tests for config file with concurrency."""
+
+    def test_project_config_with_concurrency(self, tmp_path):
+        """Test loading project config with concurrency section."""
+        # Create project config
+        arborist_home = tmp_path / ".arborist"
+        arborist_home.mkdir()
+
+        config_data = {
+            "concurrency": {
+                "max_ai_tasks": 3
+            }
+        }
+        config_path = arborist_home / "config.json"
+        config_path.write_text(json.dumps(config_data))
+
+        # Load config
+        config = get_config(arborist_home)
+
+        assert config.concurrency.max_ai_tasks == 3
+
+    def test_global_config_with_concurrency(self, tmp_path, monkeypatch):
+        """Test loading global config with concurrency section."""
+        # Create global config
+        global_config_path = tmp_path / ".arborist_config.json"
+        config_data = {
+            "concurrency": {
+                "max_ai_tasks": 8
+            }
+        }
+        global_config_path.write_text(json.dumps(config_data))
+
+        # Patch home directory
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        # Load config (no arborist_home)
+        config = get_config()
+
+        assert config.concurrency.max_ai_tasks == 8


### PR DESCRIPTION
## Summary

Adds simple concurrency control using DAGU's queue system to limit concurrent AI task execution.

- Add `ConcurrencyConfig` with `max_ai_tasks` setting (default: 2)
- Add `queue` field to `SubDagStep` for DAGU queue assignment
- Assign `arborist:ai` queue to `run` and `post-merge` steps
- Add `arborist config sync-queues` CLI command
- Support `ARBORIST_MAX_AI_TASKS` environment variable
- Add comprehensive test coverage (32 tests)

## Configuration

```json
{
  "concurrency": {
    "max_ai_tasks": 2
  }
}
```

Or via environment variable:
```bash
export ARBORIST_MAX_AI_TASKS=2
```

## Usage

```bash
arborist config sync-queues  # Sync to DAGU config
arborist spec dag-build foo  # DAGs include queue assignments
```

## Test Plan

- [x] 32 new concurrency tests pass
- [x] All existing config/dag_builder tests pass (137 total)
- [ ] Manual test: `arborist config init` creates config with concurrency section
- [ ] Manual test: `arborist config sync-queues` creates DAGU queue config