### PR TITLE
Add arborist pull/push CLI commands for remote branch sync

### DIFF
--- a/docs/examples/arborist-run.yml
+++ b/docs/examples/arborist-run.yml
@@ -22,6 +22,10 @@ on:
         description: 'Container mode override (auto, enabled, disabled)'
         required: false
         type: string
+      tree_path:
+        description: 'Path to task-tree.json (default: specs/{branch}/task-tree.json)'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -38,18 +42,6 @@ jobs:
         with:
           ref: ${{ inputs.spec_branch }}
           fetch-depth: 0
-
-      - name: Pull existing arborist branches (resume support)
-        run: |
-          echo "Fetching arborist/* branches for resume support..."
-          git fetch origin 'refs/heads/arborist/*:refs/remotes/origin/arborist/*' 2>/dev/null || true
-          for rb in $(git branch -r --list 'origin/arborist/*' 2>/dev/null); do
-            branch="${rb#origin/}"
-            if ! git rev-parse --verify "$branch" >/dev/null 2>&1; then
-              git branch "$branch" "$rb"
-              echo "  Restored: $branch"
-            fi
-          done
 
       - name: Setup Python 3.11
         uses: actions/setup-python@v5
@@ -69,6 +61,9 @@ jobs:
       - name: Install agent-arborist
         run: pip install git+https://${{ secrets.GH_PAT_ARBORIST_RO }}@github.com/pennyworth-tech/agent-arborist.git
 
+      - name: Pull existing arborist branches (resume support)
+        run: arborist pull ${{ inputs.tree_path && format('--tree {0}', inputs.tree_path) || '' }}
+
       - name: Install Claude Code
         if: inputs.runner_type == 'claude' || inputs.runner_type == ''
         run: npm install -g @anthropic-ai/claude-code
@@ -87,6 +82,7 @@ jobs:
       - name: Run gardener
         run: |
           cmd="arborist gardener --base-branch '${{ inputs.spec_branch }}'"
+          [ -n "${{ inputs.tree_path }}" ]       && cmd="$cmd --tree '${{ inputs.tree_path }}'"
           [ -n "${{ inputs.runner_type }}" ]    && cmd="$cmd --runner-type '${{ inputs.runner_type }}'"
           [ -n "${{ inputs.model }}" ]           && cmd="$cmd --model '${{ inputs.model }}'"
           [ -n "${{ inputs.max_retries }}" ]     && cmd="$cmd --max-retries ${{ inputs.max_retries }}"
@@ -100,9 +96,5 @@ jobs:
       - name: Push arborist branches + base
         if: always()
         run: |
-          echo "Pushing arborist branches to preserve progress..."
-          for branch in $(git branch --list 'arborist/*' 2>/dev/null); do
-            branch=$(echo "$branch" | xargs)
-            git push origin "$branch" --force-with-lease 2>/dev/null || echo "  skip: $branch"
-          done
+          arborist push ${{ inputs.tree_path && format('--tree {0}', inputs.tree_path) || '' }}
           git push origin "${{ inputs.spec_branch }}" --force-with-lease 2>/dev/null || echo "  skip: base branch"

--- a/src/agent_arborist/git/repo.py
+++ b/src/agent_arborist/git/repo.py
@@ -98,9 +98,37 @@ def git_diff(ref1: str, ref2: str, cwd: Path) -> str:
     return _run(["diff", f"{ref1}..{ref2}"], cwd)
 
 
-def git_branch_list(cwd: Path) -> list[str]:
+def git_branch_list(cwd: Path, pattern: str | None = None) -> list[str]:
+    args = ["branch", "--list", "--format=%(refname:short)"]
+    if pattern:
+        args.append(pattern)
     try:
-        out = _run(["branch", "--list", "--format=%(refname:short)"], cwd)
+        out = _run(args, cwd)
     except GitError:
         return []
     return [b for b in out.split("\n") if b]
+
+
+def git_remote_branch_list(cwd: Path, pattern: str | None = None) -> list[str]:
+    args = ["branch", "-r", "--list", "--format=%(refname:short)"]
+    if pattern:
+        args.append(pattern)
+    try:
+        out = _run(args, cwd)
+    except GitError:
+        return []
+    return [b for b in out.split("\n") if b]
+
+
+def git_fetch(cwd: Path, refspec: str | None = None) -> None:
+    args = ["fetch", "origin"]
+    if refspec:
+        args.append(refspec)
+    _run(args, cwd)
+
+
+def git_push(cwd: Path, branch: str, *, force_with_lease: bool = False) -> None:
+    args = ["push", "origin", branch]
+    if force_with_lease:
+        args.append("--force-with-lease")
+    _run(args, cwd)


### PR DESCRIPTION
## Summary
- Add `arborist pull` and `arborist push` CLI commands scoped to the task tree's `{namespace}/{spec_id}/*` branches
- Add git helpers: `git_fetch`, `git_push`, `git_remote_branch_list`, pattern support for `git_branch_list`
- Update GH Action template to use `arborist pull`/`arborist push` instead of inline git scripts
- Add optional `tree_path` workflow input to override default task tree location
- 8 new tests for pull/push commands

## Test plan
- [x] All 231 existing tests pass
- [x] New tests cover: fetch+restore, skip existing, push matching, push failures, default tree path, prefix scoping