### PR TITLE
Fix review loop: run-start commit + stat-only diff

### DIFF
--- a/src/agent_arborist/git/repo.py
+++ b/src/agent_arborist/git/repo.py
@@ -98,6 +98,10 @@ def git_diff(ref1: str, ref2: str, cwd: Path) -> str:
     return _run(["diff", f"{ref1}..{ref2}"], cwd)
 
 
+def git_diff_stat(ref1: str, ref2: str, cwd: Path) -> str:
+    return _run(["diff", "--stat", f"{ref1}..{ref2}"], cwd)
+
+
 def git_branch_list(cwd: Path, pattern: str | None = None) -> list[str]:
     args = ["branch", "--list", "--format=%(refname:short)"]
     if pattern:

--- a/src/agent_arborist/worker/gardener.py
+++ b/src/agent_arborist/worker/gardener.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
-from agent_arborist.git.state import scan_completed_tasks
+from agent_arborist.git.state import get_run_start_sha, scan_completed_tasks
 from agent_arborist.tree.model import TaskTree
 from agent_arborist.worker.garden import garden, find_next_task
 
@@ -43,6 +43,9 @@ def gardener(
     result = GardenerResult(success=False)
     all_leaves = {n.id for n in tree.leaves()}
 
+    # Create run-start marker once for the entire gardener run
+    run_start_sha = get_run_start_sha(cwd, branch=branch)
+
     while True:
         completed = scan_completed_tasks(tree, cwd, branch=branch)
         logger.debug("Completed tasks: %s", completed)
@@ -74,6 +77,7 @@ def gardener(
             container_up_timeout=container_up_timeout,
             container_check_timeout=container_check_timeout,
             branch=branch,
+            run_start_sha=run_start_sha,
         )
 
         if gr.success:


### PR DESCRIPTION
## Summary
- Add `get_run_start_sha()` to create a stable baseline marker commit per run
- Add `git_diff_stat()` for `--stat` only diffs  
- Replace truncated full diff in review with stat summary so reviewers see deliverables
- Gardener creates run-start once and passes it to all `garden()` calls

Fixes #41

## Test plan
- [x] `pytest tests/` — 213 passed
- [ ] Run `arborist garden` — confirm run-start commit created, review uses `--stat` output
- [ ] Run `arborist gardener` — confirm single run-start commit, reused across tasks