### PR TITLE
Fix #49: Remove lexicographic sorting from execution order calculation

### DIFF
--- a/src/agent_arborist/tree/model.py
+++ b/src/agent_arborist/tree/model.py
@@ -101,7 +101,7 @@ class TaskTree:
 
         Only includes leaf tasks (actual work items).
         """
-        leaves = {n.id for n in self.leaves()}
+        leaves = [n.id for n in self.leaves()]
 
         # Build in-degree map for leaf dependencies
         in_degree: dict[str, int] = {}
@@ -116,13 +116,13 @@ class TaskTree:
                 dependents.setdefault(d, []).append(nid)
 
         # Kahn's: start with nodes that have no dependencies
-        queue = deque(sorted(nid for nid, deg in in_degree.items() if deg == 0))
+        queue = deque(nid for nid, deg in in_degree.items() if deg == 0)
         order: list[str] = []
 
         while queue:
             nid = queue.popleft()
             order.append(nid)
-            for dep in sorted(dependents.get(nid, [])):
+            for dep in dependents.get(nid, []):
                 in_degree[dep] -= 1
                 if in_degree[dep] == 0:
                     queue.append(dep)

--- a/tests/tree/test_model.py
+++ b/tests/tree/test_model.py
@@ -62,7 +62,7 @@ def test_compute_execution_order_no_deps():
     tree.nodes["T001"] = TaskNode(id="T001", name="A", parent="phase1")
     tree.nodes["T002"] = TaskNode(id="T002", name="B", parent="phase1")
     order = tree.compute_execution_order()
-    # Both have no deps, sorted alphabetically
+    # Both have no deps, preserves insertion order from tree.nodes
     assert order == ["T001", "T002"]
 
 
@@ -132,6 +132,21 @@ def test_to_dict_and_from_dict_roundtrip():
     assert set(restored.nodes.keys()) == set(tree.nodes.keys())
     assert restored.nodes["T002"].depends_on == ["T001"]
     assert restored.execution_order == ["T001", "T002"]
+
+
+def test_compute_execution_order_preserves_spec_order():
+    """Test that execution order preserves spec insertion order, not lexicographic."""
+    tree = TaskTree()
+    # Insert tasks in a specific order: T003, T001, T002
+    tree.nodes["root"] = TaskNode(id="root", name="Root", children=["T003", "T001", "T002"])
+    tree.nodes["T003"] = TaskNode(id="T003", name="Third", parent="root")
+    tree.nodes["T001"] = TaskNode(id="T001", name="First", parent="root")
+    tree.nodes["T002"] = TaskNode(id="T002", name="Second", parent="root")
+
+    order = tree.compute_execution_order()
+    # Should preserve insertion order (T003, T001, T002), not sort alphabetically
+    assert order == ["T003", "T001", "T002"]
+    assert order != sorted(order), "Order should not be sorted alphabetically"
 
 
 # --- TestCommand / TestType tests ---


### PR DESCRIPTION
## Summary

Fixes #49. Removes lexicographic sorting from `TaskTree.compute_execution_order()` so tasks execute in spec insertion order instead of alphabetical order.

## Problem

The gardener was executing tasks lexicographically (T001, T002, etc.) instead of following the spec's intended order. This happened because `compute_execution_order()` in `src/agent_arborist/tree/model.py` was using `sorted()` calls in Kahn's algorithm:
- Line 119: `queue = deque(sorted(nid for nid, deg in in_degree.items() if deg == 0))`
- Line 125: `for dep in sorted(dependents.get(nid, [])):`

These forced alphabetical ordering when multiple tasks had the same in-degree.

## Solution

1. Changed `leaves` from a set to a list to preserve iteration order
2. Removed `sorted()` calls from queue initialization and dependent processing
3. Tasks now follow Python dict insertion order (spec order) instead of being sorted

## Changes

- **src/agent_arborist/tree/model.py**: 
  - Line 104: `leaves = [n.id for n in self.leaves()]` (was a set)
  - Line 119: Removed `sorted()` from queue initialization
  - Line 125: Removed `sorted()` from dependent iteration
  
- **tests/tree/test_model.py**:
  - Updated test comment to reflect new behavior
  - Added `test_compute_execution_order_preserves_spec_order()` to verify spec order is preserved

## Testing

- All 214 existing tests pass
- New test verifies tasks execute in insertion order, not lexicographic order
- Verified with real spec (calculator fixture) that execution order preserves spec document order

## Example

Before (sorted lexicographically):
```
T001 -> T002 -> T003 -> T004
```

But if spec defines order as `T003, T001, T002`, after fix:
```
T003 -> T001 -> T002 -> T004
```

Dependencies are still respected - only the tie-breaker order changed.