### PR TITLE
Add live dashboard for monitoring arborist runs

### DIFF
--- a/dashboard/serve-dashboard.py
+++ b/dashboard/serve-dashboard.py
@@ -3,8 +3,12 @@
 Arborist Run Dashboard — Live Server
 Reads task-tree, reports, and logs from disk on each request.
 
+NOTE: This is a standalone prototype. Ideally this functionality should be
+folded into the arborist CLI itself (e.g. `arborist dashboard`) rather than
+living as a separate Python script.
+
 Usage:
-    python3 docs/tasks/serve-dashboard.py [--port 8484] [--tree docs/tasks/task-tree-opus.json]
+    python3 dashboard/serve-dashboard.py [--port 8484] [--tree docs/tasks/task-tree-opus.json]
 
 Then open http://localhost:8484
 """


### PR DESCRIPTION
## Summary

- Adds a self-contained Python 3 HTTP server that serves a real-time web dashboard for monitoring arborist task execution
- Reads the task tree JSON, reports, and logs from disk on each request — no database or external dependencies required
- Auto-refreshes every 5 seconds

## Usage

```bash
python3 dashboard/serve-dashboard.py [--port 8484] [--tree PATH] [--reports DIR] [--logs DIR]
```

Then open http://localhost:8484.

### CLI options

| Flag | Default | Description |
|------|---------|-------------|
| `--port` | `8484` | Server port |
| `--tree` | `dashboard/task-tree-opus.json` | Path to task tree JSON |
| `--reports` | `dashboard/reports/` | Reports directory |
| `--logs` | `dashboard/logs/` | Logs directory |

## Dashboard panels

- **Overall progress** — completed vs total tasks, elapsed time
- **Milestones** — per-milestone progress bars and completion status
- **Attempts table** — per-task implement/review counts with clean/retry badges
- **Duration distribution** — histogram of task durations
- **Full plan view** — collapsible milestone tree with pass/retry/pending/running badges
- **Gantt timeline** — visual timeline of implement/review/test phases with retry highlighting and hover tooltips
- **Test runner** — on-demand jest execution with pass/fail breakdown by suite

## Future work

This is a standalone prototype. Ideally this functionality should be folded into the arborist CLI itself (e.g. `arborist dashboard`) rather than living as a separate Python script. Additionally, the ~680-line HTML/CSS/JS template is currently inlined in the script — it should be extracted to a separate `.html` template file so the dashboard layout can be edited independently of the server logic.


🤖 Generated with [Claude Code](https://claude.com/claude-code)