### PR TITLE
fix: defer git_current_branch in build command

### DIFF
--- a/src/agent_arborist/cli.py
+++ b/src/agent_arborist/cli.py
@@ -162,12 +162,13 @@ def init():
               help="Container mode for AI planning (default: from config or 'auto')")
 def build(spec_dir, output, no_ai, runner, model, container_mode):
     """Build a task tree from a spec directory and write it to a JSON file."""
-    branch = git_current_branch(Path.cwd())
-    spec_id = spec_id_from_branch(branch)
-    if spec_dir is None:
-        spec_dir = Path("openspec") / "changes" / spec_id
-    if output is None:
-        output = Path("openspec") / "changes" / spec_id / "task-tree.json"
+    if spec_dir is None or output is None:
+        branch = git_current_branch(Path.cwd())
+        spec_id = spec_id_from_branch(branch)
+        if spec_dir is None:
+            spec_dir = Path("openspec") / "changes" / spec_id
+        if output is None:
+            output = Path("openspec") / "changes" / spec_id / "task-tree.json"
     if no_ai:
         from agent_arborist.tree.spec_parser import parse_spec
         spec_files = list(spec_dir.glob("tasks*.md")) + list(spec_dir.glob("*.md"))


### PR DESCRIPTION
## Summary

- Fixes `arborist build` crash when run in a repo with no commits and `--spec-dir`/`--output` are explicitly provided
- Defers `git_current_branch()` call so it only runs when needed to derive default paths

Closes #72

## Test plan

- [ ] Run `arborist build --spec-dir <path> --output <path>` in a repo with no commits — should no longer crash
- [ ] Run `arborist build` without flags on a normal branch — should still derive defaults correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)