### PR TITLE
fix: handle --output pointing to a directory in build command

### DIFF
--- a/src/agent_arborist/cli.py
+++ b/src/agent_arborist/cli.py
@@ -202,6 +202,8 @@ def build(spec_dir, output, no_ai, runner, model, container_mode):
 
     # Write task tree JSON
     tree_path = Path(output).resolve()
+    if tree_path.is_dir():
+        tree_path = tree_path / "task-tree.json"
     tree_path.parent.mkdir(parents=True, exist_ok=True)
     tree_path.write_text(json.dumps(tree.to_dict(), indent=2) + "\n")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -419,6 +419,24 @@ class TestDefaultTreePath:
             result = runner.invoke(main, ["garden"])
         assert result.exit_code != 0
 
+    def test_build_output_directory_appends_filename(self, tmp_path):
+        """build with --output pointing to a directory appends task-tree.json."""
+        out_dir = tmp_path / "spec"
+        out_dir.mkdir()
+        runner = CliRunner()
+        with patch("agent_arborist.cli.git_current_branch", return_value="my-branch"), \
+             patch("agent_arborist.cli.git_toplevel", return_value=str(tmp_path)):
+            result = runner.invoke(main, [
+                "build", "--no-ai",
+                "--spec-dir", str(FIXTURES),
+                "--output", str(out_dir),
+            ])
+        assert result.exit_code == 0, result.output
+        expected = out_dir / "task-tree.json"
+        assert expected.exists()
+        data = json.loads(expected.read_text())
+        assert "nodes" in data
+
     def test_build_with_dashdash_branch(self, tmp_path):
         """build with a branch like feature/feat--v1 extracts spec_id and creates openspec/changes/{spec_id}/."""
         runner = CliRunner()


### PR DESCRIPTION
## Summary
- When `--output` is passed a directory path (e.g. `--output spec/`), the build command now appends `task-tree.json` as the filename instead of crashing with `IsADirectoryError`

## Test plan
- [x] Added `test_build_output_directory_appends_filename` verifying directory output auto-appends filename
- [x] All 34 existing CLI tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)