### PR TITLE
Refactor spec_id_from_branch to extract team-NN as spec_id

### DIFF
--- a/src/agent_arborist/git/repo.py
+++ b/src/agent_arborist/git/repo.py
@@ -181,20 +181,27 @@ def git_log_since(
 def spec_id_from_branch(branch: str) -> str:
     """Extract spec ID from branch name.
 
-    Strips optional 'feature/' prefix and everything after '--'.
+    Strips optional 'feature/' prefix, everything after '--', and everything
+    after the first two hyphen-separated fields.
 
-    Git branch refs are stored as files under .git/refs/heads/. Using '/'
-    as a terminator causes conflicts (can't have both a file and directory
-    at the same path). Using '--' avoids this issue.
+    Per OS-47 on Linear, the branch naming convention is:
+        team-NN-<<<slug>>>--<<timeline>>
+
+    The spec_id is the 'team-NN' portion (e.g., 'os-47').
 
     Examples:
-        'bl-jjjj-blah-blah' -> 'bl-jjjj-blah-blah'
-        'bl-jjjj-blah-blah--v1' -> 'bl-jjjj-blah-blah'
-        'feature/bl-jjjj-blah-blah' -> 'bl-jjjj-blah-blah'
-        'feature/bl-jjjj-blah-blah--v2' -> 'bl-jjjj-blah-blah'
+        'os-47-split-spec-branch-timeline--v1' -> 'os-47'
+        'bltest-123-another-slug--v2' -> 'bltest-123'
+        'feature/os-47-slug--v3' -> 'os-47'
+        'bl-jjjj-blah-blah' -> 'bl-jjjj'
     """
     if branch.startswith("feature/"):
         branch = branch[8:]
     if "--" in branch:
         branch = branch.split("--")[0]
+
+    # Extract first two hyphen-separated fields (e.g., team-NN)
+    parts = branch.split("-")
+    if len(parts) >= 2:
+        return "-".join(parts[:2])
     return branch

--- a/tests/git/test_repo.py
+++ b/tests/git/test_repo.py
@@ -115,10 +115,18 @@ def test_git_log_with_grep(git_repo):
 
 
 def test_spec_id_from_branch():
-    assert spec_id_from_branch("bl-jjjj-blah-blah") == "bl-jjjj-blah-blah"
-    assert spec_id_from_branch("bl-jjjj-blah-blah--v1") == "bl-jjjj-blah-blah"
-    assert spec_id_from_branch("bl-jjjj-blah-blah--v2--extra") == "bl-jjjj-blah-blah"
-    assert spec_id_from_branch("feature/bl-jjjj-blah-blah") == "bl-jjjj-blah-blah"
-    assert spec_id_from_branch("feature/bl-jjjj-blah-blah--v1") == "bl-jjjj-blah-blah"
-    assert spec_id_from_branch("feature/bl-jjjj-blah-blah--v200--extra") == "bl-jjjj-blah-blah"
-    assert spec_id_from_branch("feature/bl-jjj-blah-blah--anything") == "bl-jjj-blah-blah"
+    # New logic: Extracts team-NN (first two fields)
+    assert spec_id_from_branch("os-47-split-spec-branch-timeline--v1") == "os-47"
+    assert spec_id_from_branch("bltest-123-another-slug--v2") == "bltest-123"
+    assert spec_id_from_branch("feature/os-47-slug--v3") == "os-47"
+
+    # Multiple hyphens in slug
+    assert spec_id_from_branch("bl-jjjj-blah-blah") == "bl-jjjj"
+    assert spec_id_from_branch("bl-jjjj-blah-blah--v1") == "bl-jjjj"
+
+    # Edge cases
+    assert spec_id_from_branch("onlyone") == "onlyone"
+    assert spec_id_from_branch("feature/onlyone") == "onlyone"
+    assert spec_id_from_branch("one-two") == "one-two"
+    assert spec_id_from_branch("one-two-three") == "one-two"
+    assert spec_id_from_branch("one-two--v1") == "one-two"


### PR DESCRIPTION
Refactor the  logic to return only the first two hyphen-separated fields (e.g., ) as the . This aligns with the  convention described in OS-47.

### Changes:
- Modified  to only extract the first two fields.
- Updated  with new test cases.
- All 247 project tests passed.

### Extraction Examples:
- `os-47-split-spec-branch-timeline--v1` -> `os-47`
- `bltest-123-another-slug--v2` -> `bltest-123`
- `feature/os-47-slug--v3` -> `os-47`
- `bl-jjjj-blah-blah` -> `bl-jjjj`

Closes #76
Linked to Linear issue: [OS-47](https://linear.app/backlit/issue/OS-47/split-spec-branch-timeline-well)